### PR TITLE
Add invokedynamic operations and start to use Dynalink

### DIFF
--- a/rhino/src/main/java/module-info.java
+++ b/rhino/src/main/java/module-info.java
@@ -12,5 +12,6 @@ module org.mozilla.rhino {
     exports org.mozilla.javascript.xml;
 
     requires java.compiler;
+    requires jdk.dynalink;
     requires transitive java.desktop;
 }

--- a/rhino/src/main/java/org/mozilla/javascript/BoundFunction.java
+++ b/rhino/src/main/java/org/mozilla/javascript/BoundFunction.java
@@ -57,8 +57,9 @@ public class BoundFunction extends BaseFunction {
 
     @Override
     public Scriptable construct(Context cx, Scriptable scope, Object[] extraArgs) {
-        if (targetFunction instanceof Function) {
-            return ((Function) targetFunction).construct(cx, scope, concat(boundArgs, extraArgs));
+        if (targetFunction instanceof Constructable) {
+            return ((Constructable) targetFunction)
+                    .construct(cx, scope, concat(boundArgs, extraArgs));
         }
         throw ScriptRuntime.typeErrorById("msg.not.ctor");
     }

--- a/rhino/src/main/java/org/mozilla/javascript/Delegator.java
+++ b/rhino/src/main/java/org/mozilla/javascript/Delegator.java
@@ -267,7 +267,7 @@ public class Delegator implements Function, SymbolScriptable {
      *     closure.
      * @param args the array of arguments
      * @return the allocated object
-     * @see Function#construct(Context, Scriptable, Object[])
+     * @see Constructable#construct(Context, Scriptable, Object[])
      */
     @Override
     public Scriptable construct(Context cx, Scriptable scope, Object[] args) {
@@ -284,6 +284,6 @@ public class Delegator implements Function, SymbolScriptable {
             n.setDelegee(delegee);
             return n;
         }
-        return ((Function) myDelegee).construct(cx, scope, args);
+        return ((Constructable) myDelegee).construct(cx, scope, args);
     }
 }

--- a/rhino/src/main/java/org/mozilla/javascript/Hashtable.java
+++ b/rhino/src/main/java/org/mozilla/javascript/Hashtable.java
@@ -123,20 +123,25 @@ public class Hashtable implements Serializable, Iterable<Hashtable.Entry> {
     public void put(Object key, Object value) {
         final Entry nv = new Entry(key, value);
 
-        if (!map.containsKey(nv)) {
-            // New value -- insert to end of doubly-linked list
-            map.put(nv, nv);
-            if (first == null) {
-                first = last = nv;
-            } else {
-                last.next = nv;
-                nv.prev = last;
-                last = nv;
-            }
-        } else {
-            // Update the existing value and keep it in the same place in the list
-            map.get(nv).value = value;
-        }
+        map.compute(
+                nv,
+                (k, existing) -> {
+                    if (existing == null) {
+                        // New value -- insert to end of doubly-linked list
+                        if (first == null) {
+                            first = last = nv;
+                        } else {
+                            last.next = nv;
+                            nv.prev = last;
+                            last = nv;
+                        }
+                        return nv;
+                    } else {
+                        // Update the existing value and keep it in the same place in the list
+                        existing.value = value;
+                        return existing;
+                    }
+                });
     }
 
     /**

--- a/rhino/src/main/java/org/mozilla/javascript/Interpreter.java
+++ b/rhino/src/main/java/org/mozilla/javascript/Interpreter.java
@@ -2035,10 +2035,10 @@ public final class Interpreter extends Icode implements Evaluator {
                                             lhs = ScriptRuntime.wrapNumber(sDbl[stackTop]);
                                         throw ScriptRuntime.notFunctionError(lhs);
                                     }
-                                    Function fun = (Function) lhs;
+                                    Constructable ctor = (Constructable) lhs;
 
-                                    if (fun instanceof IdFunctionObject) {
-                                        IdFunctionObject ifun = (IdFunctionObject) fun;
+                                    if (ctor instanceof IdFunctionObject) {
+                                        IdFunctionObject ifun = (IdFunctionObject) ctor;
                                         if (NativeContinuation.isContinuationConstructor(ifun)) {
                                             frame.stack[stackTop] =
                                                     captureContinuation(
@@ -2049,7 +2049,7 @@ public final class Interpreter extends Icode implements Evaluator {
 
                                     Object[] outArgs =
                                             getArgsArray(stack, sDbl, stackTop + 1, indexReg);
-                                    stack[stackTop] = fun.construct(cx, frame.scope, outArgs);
+                                    stack[stackTop] = ctor.construct(cx, frame.scope, outArgs);
                                     continue Loop;
                                 }
                             case Token.TYPEOF:

--- a/rhino/src/main/java/org/mozilla/javascript/NativeArray.java
+++ b/rhino/src/main/java/org/mozilla/javascript/NativeArray.java
@@ -905,13 +905,13 @@ public class NativeArray extends IdScriptableObject implements List {
             Context cx, Scriptable scope, Scriptable arg, long length, boolean lengthAlways) {
         Scriptable result = null;
 
-        if (arg instanceof Function) {
+        if (arg instanceof Constructable) {
             try {
                 final Object[] args =
                         (lengthAlways || (length > 0))
                                 ? new Object[] {Long.valueOf(length)}
                                 : ScriptRuntime.emptyArgs;
-                result = ((Function) arg).construct(cx, scope, args);
+                result = ((Constructable) arg).construct(cx, scope, args);
             } catch (EcmaError ee) {
                 if (!"TypeError".equals(ee.getName())) {
                     throw ee;
@@ -1719,9 +1719,8 @@ public class NativeArray extends IdScriptableObject implements List {
 
         if (cx.getLanguageVersion() < Context.VERSION_ES6) {
             // Otherwise, for older Rhino versions, fall back to the old algorithm, which treats
-            // things with
-            // the Array constructor as arrays. However, this is contrary to ES6!
-            final Function ctor = ScriptRuntime.getExistingCtor(cx, scope, "Array");
+            // things with the Array constructor as arrays. However, this is contrary to ES6!
+            final Constructable ctor = ScriptRuntime.getExistingCtor(cx, scope, "Array");
             if (ScriptRuntime.instanceOf(val, ctor, cx)) {
                 return true;
             }

--- a/rhino/src/main/java/org/mozilla/javascript/NativeJavaClass.java
+++ b/rhino/src/main/java/org/mozilla/javascript/NativeJavaClass.java
@@ -167,10 +167,9 @@ public class NativeJavaClass extends NativeJavaObject implements Function {
             // implements/extends this interface/abstract class.
             Object v = topLevel.get("JavaAdapter", topLevel);
             if (v != NOT_FOUND) {
-                Function f = (Function) v;
                 // Args are (interface, js object)
                 Object[] adapterArgs = {this, args[0]};
-                return f.construct(cx, topLevel, adapterArgs);
+                return ((Constructable) v).construct(cx, topLevel, adapterArgs);
             }
         } catch (Exception ex) {
             // fall through to error

--- a/rhino/src/main/java/org/mozilla/javascript/NativePromise.java
+++ b/rhino/src/main/java/org/mozilla/javascript/NativePromise.java
@@ -688,7 +688,6 @@ public class NativePromise extends ScriptableObject {
             if (!(pc instanceof Constructable)) {
                 throw ScriptRuntime.typeErrorById("msg.constructor.expected");
             }
-            Constructable promiseConstructor = (Constructable) pc;
             LambdaFunction executorFunc =
                     new LambdaFunction(
                             topScope,
@@ -696,7 +695,7 @@ public class NativePromise extends ScriptableObject {
                             (Context cx, Scriptable scope, Scriptable thisObj, Object[] args) ->
                                     executor(args));
 
-            promise = promiseConstructor.construct(topCx, topScope, new Object[] {executorFunc});
+            promise = ((Constructable) pc).construct(topCx, topScope, new Object[] {executorFunc});
 
             if (!(rawResolve instanceof Callable)) {
                 throw ScriptRuntime.typeErrorById("msg.function.expected");

--- a/rhino/src/main/java/org/mozilla/javascript/ScriptRuntime.java
+++ b/rhino/src/main/java/org/mozilla/javascript/ScriptRuntime.java
@@ -1330,7 +1330,7 @@ public class ScriptRuntime {
     public static Scriptable newObject(
             Context cx, Scriptable scope, String constructorName, Object[] args) {
         scope = ScriptableObject.getTopLevelScope(scope);
-        Function ctor = getExistingCtor(cx, scope, constructorName);
+        Constructable ctor = getExistingCtor(cx, scope, constructorName);
         if (args == null) {
             args = ScriptRuntime.emptyArgs;
         }
@@ -1340,7 +1340,7 @@ public class ScriptRuntime {
     public static Scriptable newBuiltinObject(
             Context cx, Scriptable scope, TopLevel.Builtins type, Object[] args) {
         scope = ScriptableObject.getTopLevelScope(scope);
-        Function ctor = TopLevel.getBuiltinCtor(cx, scope, type);
+        Constructable ctor = TopLevel.getBuiltinCtor(cx, scope, type);
         if (args == null) {
             args = ScriptRuntime.emptyArgs;
         }
@@ -1350,7 +1350,7 @@ public class ScriptRuntime {
     static Scriptable newNativeError(
             Context cx, Scriptable scope, TopLevel.NativeErrors type, Object[] args) {
         scope = ScriptableObject.getTopLevelScope(scope);
-        Function ctor = TopLevel.getNativeErrorCtor(cx, scope, type);
+        Constructable ctor = TopLevel.getNativeErrorCtor(cx, scope, type);
         if (args == null) {
             args = ScriptRuntime.emptyArgs;
         }
@@ -2768,11 +2768,10 @@ public class ScriptRuntime {
      * <p>See ECMA 11.2.2
      */
     public static Scriptable newObject(Object fun, Context cx, Scriptable scope, Object[] args) {
-        if (!(fun instanceof Function)) {
+        if (!(fun instanceof Constructable)) {
             throw notFunctionError(fun);
         }
-        Function function = (Function) fun;
-        return function.construct(cx, scope, args);
+        return ((Constructable) fun).construct(cx, scope, args);
     }
 
     public static Object callSpecial(

--- a/rhino/src/main/java/org/mozilla/javascript/optimizer/BodyCodegen.java
+++ b/rhino/src/main/java/org/mozilla/javascript/optimizer/BodyCodegen.java
@@ -986,12 +986,10 @@ class BodyCodegen {
                 {
                     cfw.addALoad(contextLocal);
                     cfw.addALoad(variableObjectLocal);
-                    cfw.addPush(node.getString());
-                    addScriptRuntimeInvoke(
-                            "name",
+                    addDynamicInvoke(
+                            "NAME:GET:" + node.getString(),
                             "(Lorg/mozilla/javascript/Context;"
                                     + "Lorg/mozilla/javascript/Scriptable;"
-                                    + "Ljava/lang/String;"
                                     + ")Ljava/lang/Object;");
                 }
                 break;
@@ -1487,12 +1485,10 @@ class BodyCodegen {
                     // Generate code for "ScriptRuntime.bind(varObj, "s")"
                     cfw.addALoad(contextLocal);
                     cfw.addALoad(variableObjectLocal);
-                    cfw.addPush(node.getString());
-                    addScriptRuntimeInvoke(
-                            "bind",
+                    addDynamicInvoke(
+                            "NAME:BIND:" + node.getString(),
                             "(Lorg/mozilla/javascript/Context;"
                                     + "Lorg/mozilla/javascript/Scriptable;"
-                                    + "Ljava/lang/String;"
                                     + ")Lorg/mozilla/javascript/Scriptable;");
                 }
                 break;
@@ -1667,13 +1663,13 @@ class BodyCodegen {
         if (unnestedYields.containsKey(node)) {
             // Yield was previously moved up via the "nestedYield" code below.
             if (exprContext) {
+                String property = unnestedYields.get(node);
                 cfw.addALoad(variableObjectLocal);
-                cfw.addLoadConstant(unnestedYields.get(node));
                 cfw.addALoad(contextLocal);
                 cfw.addALoad(variableObjectLocal);
-                addScriptRuntimeInvoke(
-                        "getObjectPropNoWarn",
-                        "(Ljava/lang/Object;Ljava/lang/String;Lorg/mozilla/javascript/Context;"
+                addDynamicInvoke(
+                        "PROP:GETNOWARN:" + property,
+                        "(Ljava/lang/Object;Lorg/mozilla/javascript/Context;"
                                 + "Lorg/mozilla/javascript/Scriptable;)Ljava/lang/Object;");
             }
             return;
@@ -2632,13 +2628,11 @@ class BodyCodegen {
                     Node id = target.getNext();
                     if (type == Token.GETPROP) {
                         String property = id.getString();
-                        cfw.addPush(property);
                         cfw.addALoad(contextLocal);
                         cfw.addALoad(variableObjectLocal);
-                        addScriptRuntimeInvoke(
-                                "getPropFunctionAndThis",
+                        addDynamicInvoke(
+                                "PROP:GETWITHTHIS:" + property,
                                 "(Ljava/lang/Object;"
-                                        + "Ljava/lang/String;"
                                         + "Lorg/mozilla/javascript/Context;"
                                         + "Lorg/mozilla/javascript/Scriptable;"
                                         + ")Lorg/mozilla/javascript/Callable;");
@@ -2661,13 +2655,11 @@ class BodyCodegen {
             case Token.NAME:
                 {
                     String name = node.getString();
-                    cfw.addPush(name);
                     cfw.addALoad(contextLocal);
                     cfw.addALoad(variableObjectLocal);
-                    addScriptRuntimeInvoke(
-                            "getNameFunctionAndThis",
-                            "(Ljava/lang/String;"
-                                    + "Lorg/mozilla/javascript/Context;"
+                    addDynamicInvoke(
+                            "NAME:GETWITHTHIS:" + name,
+                            "(Lorg/mozilla/javascript/Context;"
                                     + "Lorg/mozilla/javascript/Scriptable;"
                                     + ")Lorg/mozilla/javascript/Callable;");
                     break;
@@ -4040,39 +4032,20 @@ class BodyCodegen {
     private void visitGetProp(Node node, Node child) {
         generateExpression(child, node); // object
         Node nameChild = child.getNext();
-        generateExpression(nameChild, node); // the name
+        cfw.addALoad(contextLocal);
+        cfw.addALoad(variableObjectLocal);
+
         if (node.getType() == Token.GETPROPNOWARN) {
-            cfw.addALoad(contextLocal);
-            cfw.addALoad(variableObjectLocal);
-            addScriptRuntimeInvoke(
-                    "getObjectPropNoWarn",
+            addDynamicInvoke(
+                    "PROP:GETNOWARN:" + nameChild.getString(),
                     "(Ljava/lang/Object;"
-                            + "Ljava/lang/String;"
                             + "Lorg/mozilla/javascript/Context;"
                             + "Lorg/mozilla/javascript/Scriptable;"
                             + ")Ljava/lang/Object;");
-            return;
-        }
-        /*
-            for 'this.foo' we call getObjectProp(Scriptable...) which can
-            skip some casting overhead.
-        */
-        int childType = child.getType();
-        if (childType == Token.THIS && nameChild.getType() == Token.STRING) {
-            cfw.addALoad(contextLocal);
-            addScriptRuntimeInvoke(
-                    "getObjectProp",
-                    "(Lorg/mozilla/javascript/Scriptable;"
-                            + "Ljava/lang/String;"
-                            + "Lorg/mozilla/javascript/Context;"
-                            + ")Ljava/lang/Object;");
         } else {
-            cfw.addALoad(contextLocal);
-            cfw.addALoad(variableObjectLocal);
-            addScriptRuntimeInvoke(
-                    "getObjectProp",
+            addDynamicInvoke(
+                    "PROP:GET:" + nameChild.getString(),
                     "(Ljava/lang/Object;"
-                            + "Ljava/lang/String;"
                             + "Lorg/mozilla/javascript/Context;"
                             + "Lorg/mozilla/javascript/Scriptable;"
                             + ")Ljava/lang/Object;");
@@ -4080,47 +4053,27 @@ class BodyCodegen {
     }
 
     private void visitSetProp(int type, Node node, Node child) {
-        Node objectChild = child;
         generateExpression(child, node);
         child = child.getNext();
+        Node nameChild = child;
         if (type == Token.SETPROP_OP) {
             cfw.add(ByteCode.DUP);
+            cfw.addALoad(contextLocal);
+            cfw.addALoad(variableObjectLocal);
+            addDynamicInvoke(
+                    "PROP:GET:" + nameChild.getString(),
+                    "(Ljava/lang/Object;"
+                            + "Lorg/mozilla/javascript/Context;"
+                            + "Lorg/mozilla/javascript/Scriptable;"
+                            + ")Ljava/lang/Object;");
         }
-        Node nameChild = child;
-        generateExpression(child, node);
         child = child.getNext();
-        if (type == Token.SETPROP_OP) {
-            // stack: ... object object name -> ... object name object name
-            cfw.add(ByteCode.DUP_X1);
-            // for 'this.foo += ...' we call thisGet which can skip some
-            // casting overhead.
-            if (objectChild.getType() == Token.THIS && nameChild.getType() == Token.STRING) {
-                cfw.addALoad(contextLocal);
-                addScriptRuntimeInvoke(
-                        "getObjectProp",
-                        "(Lorg/mozilla/javascript/Scriptable;"
-                                + "Ljava/lang/String;"
-                                + "Lorg/mozilla/javascript/Context;"
-                                + ")Ljava/lang/Object;");
-            } else {
-                cfw.addALoad(contextLocal);
-                cfw.addALoad(variableObjectLocal);
-                addScriptRuntimeInvoke(
-                        "getObjectProp",
-                        "(Ljava/lang/Object;"
-                                + "Ljava/lang/String;"
-                                + "Lorg/mozilla/javascript/Context;"
-                                + "Lorg/mozilla/javascript/Scriptable;"
-                                + ")Ljava/lang/Object;");
-            }
-        }
         generateExpression(child, node);
         cfw.addALoad(contextLocal);
         cfw.addALoad(variableObjectLocal);
-        addScriptRuntimeInvoke(
-                "setObjectProp",
+        addDynamicInvoke(
+                "PROP:SET:" + nameChild.getString(),
                 "(Ljava/lang/Object;"
-                        + "Ljava/lang/String;"
                         + "Ljava/lang/Object;"
                         + "Lorg/mozilla/javascript/Context;"
                         + "Lorg/mozilla/javascript/Scriptable;"
@@ -4303,6 +4256,10 @@ class BodyCodegen {
                 "org/mozilla/javascript/optimizer/OptRuntime",
                 methodName,
                 methodSignature);
+    }
+
+    private void addDynamicInvoke(String operation, String signature) {
+        cfw.addInvokeDynamic(operation, signature, Bootstrapper.BOOTSTRAP_HANDLE);
     }
 
     private void addJumpedBooleanWrap(int trueLabel, int falseLabel) {

--- a/rhino/src/main/java/org/mozilla/javascript/optimizer/BodyCodegen.java
+++ b/rhino/src/main/java/org/mozilla/javascript/optimizer/BodyCodegen.java
@@ -1363,15 +1363,15 @@ class BodyCodegen {
                 generateExpression(child.getNext(), node); // id
                 cfw.addALoad(contextLocal);
                 if (node.getIntProp(Node.ISNUMBER_PROP, -1) != -1) {
-                    addScriptRuntimeInvoke(
-                            "getObjectIndex",
+                    addDynamicInvoke(
+                            "PROP:GETINDEX",
                             "(Ljava/lang/Object;D"
                                     + "Lorg/mozilla/javascript/Context;"
                                     + ")Ljava/lang/Object;");
                 } else {
                     cfw.addALoad(variableObjectLocal);
-                    addScriptRuntimeInvoke(
-                            "getObjectElem",
+                    addDynamicInvoke(
+                            "PROP:GETELEMENT",
                             "(Ljava/lang/Object;"
                                     + "Ljava/lang/Object;"
                                     + "Lorg/mozilla/javascript/Context;"
@@ -1688,13 +1688,10 @@ class BodyCodegen {
             unnestedYieldCount++;
             cfw.addALoad(variableObjectLocal);
             cfw.add(ByteCode.SWAP);
-            cfw.addLoadConstant(nn);
-            cfw.add(ByteCode.SWAP);
             cfw.addALoad(contextLocal);
-
-            addScriptRuntimeInvoke(
-                    "setObjectProp",
-                    "(Lorg/mozilla/javascript/Scriptable;Ljava/lang/String;Ljava/lang/Object;"
+            addDynamicInvoke(
+                    "PROP:SET:" + nn,
+                    "(Lorg/mozilla/javascript/Scriptable;Ljava/lang/Object;"
                             + "Lorg/mozilla/javascript/Context;)Ljava/lang/Object;");
             cfw.add(ByteCode.POP);
 
@@ -3867,14 +3864,12 @@ class BodyCodegen {
         }
         cfw.addALoad(contextLocal);
         cfw.addALoad(variableObjectLocal);
-        cfw.addPush(name);
-        addScriptRuntimeInvoke(
-                "setName",
+        addDynamicInvoke(
+                "NAME:SET:" + name,
                 "(Lorg/mozilla/javascript/Scriptable;"
                         + "Ljava/lang/Object;"
                         + "Lorg/mozilla/javascript/Context;"
                         + "Lorg/mozilla/javascript/Scriptable;"
-                        + "Ljava/lang/String;"
                         + ")Ljava/lang/Object;");
     }
 
@@ -3886,14 +3881,12 @@ class BodyCodegen {
         }
         cfw.addALoad(contextLocal);
         cfw.addALoad(variableObjectLocal);
-        cfw.addPush(name);
-        addScriptRuntimeInvoke(
-                "strictSetName",
+        addDynamicInvoke(
+                "NAME:SETSTRICT:" + name,
                 "(Lorg/mozilla/javascript/Scriptable;"
                         + "Ljava/lang/Object;"
                         + "Lorg/mozilla/javascript/Context;"
                         + "Lorg/mozilla/javascript/Scriptable;"
-                        + "Ljava/lang/String;"
                         + ")Ljava/lang/Object;");
     }
 
@@ -3904,13 +3897,11 @@ class BodyCodegen {
             child = child.getNext();
         }
         cfw.addALoad(contextLocal);
-        cfw.addPush(name);
-        addScriptRuntimeInvoke(
-                "setConst",
+        addDynamicInvoke(
+                "NAME:SETCONST:" + name,
                 "(Lorg/mozilla/javascript/Scriptable;"
                         + "Ljava/lang/Object;"
                         + "Lorg/mozilla/javascript/Context;"
-                        + "Ljava/lang/String;"
                         + ")Ljava/lang/Object;");
     }
 
@@ -4096,8 +4087,8 @@ class BodyCodegen {
                 cfw.add(ByteCode.DUP2_X1);
                 cfw.addALoad(contextLocal);
                 cfw.addALoad(variableObjectLocal);
-                addScriptRuntimeInvoke(
-                        "getObjectIndex",
+                addDynamicInvoke(
+                        "PROP:GETINDEX",
                         "(Ljava/lang/Object;D"
                                 + "Lorg/mozilla/javascript/Context;"
                                 + "Lorg/mozilla/javascript/Scriptable;"
@@ -4108,8 +4099,8 @@ class BodyCodegen {
                 cfw.add(ByteCode.DUP_X1);
                 cfw.addALoad(contextLocal);
                 cfw.addALoad(variableObjectLocal);
-                addScriptRuntimeInvoke(
-                        "getObjectElem",
+                addDynamicInvoke(
+                        "PROP:GETELEMENT",
                         "(Ljava/lang/Object;"
                                 + "Ljava/lang/Object;"
                                 + "Lorg/mozilla/javascript/Context;"
@@ -4121,8 +4112,8 @@ class BodyCodegen {
         cfw.addALoad(contextLocal);
         cfw.addALoad(variableObjectLocal);
         if (indexIsNumber) {
-            addScriptRuntimeInvoke(
-                    "setObjectIndex",
+            addDynamicInvoke(
+                    "PROP:SETINDEX",
                     "(Ljava/lang/Object;"
                             + "D"
                             + "Ljava/lang/Object;"
@@ -4130,8 +4121,8 @@ class BodyCodegen {
                             + "Lorg/mozilla/javascript/Scriptable;"
                             + ")Ljava/lang/Object;");
         } else {
-            addScriptRuntimeInvoke(
-                    "setObjectElem",
+            addDynamicInvoke(
+                    "PROP:SETELEMENT",
                     "(Ljava/lang/Object;"
                             + "Ljava/lang/Object;"
                             + "Ljava/lang/Object;"

--- a/rhino/src/main/java/org/mozilla/javascript/optimizer/Bootstrapper.java
+++ b/rhino/src/main/java/org/mozilla/javascript/optimizer/Bootstrapper.java
@@ -61,34 +61,69 @@ public class Bootstrapper {
         if ("PROP".equals(namespaceName)) {
             switch (opName) {
                 case "GET":
+                    // Get an object property with a constant name
                     return StandardOperation.GET
                             .withNamespace(StandardNamespace.PROPERTY)
                             .named(getNameSegment(tokens, name, 2));
                 case "GETNOWARN":
+                    // Same with no warning of strict mode
                     return RhinoOperation.GETNOWARN
                             .withNamespace(StandardNamespace.PROPERTY)
                             .named(getNameSegment(tokens, name, 2));
                 case "GETWITHTHIS":
+                    // Same but also return "this" so that it is found by "lastStoredScriptable"
                     return RhinoOperation.GETWITHTHIS
                             .withNamespace(StandardNamespace.PROPERTY)
                             .named(getNameSegment(tokens, name, 2));
+                case "GETELEMENT":
+                    // Get the value of an element from a property that is on the stack,\
+                    // as if using "[]" notation. Could be a String, number, or Symbol
+                    return RhinoOperation.GETELEMENT.withNamespace(StandardNamespace.PROPERTY);
+                case "GETINDEX":
+                    // Same but the value is definitely a numeric index
+                    return RhinoOperation.GETINDEX.withNamespace(StandardNamespace.PROPERTY);
                 case "SET":
+                    // Set an object property with a constant name
                     return StandardOperation.SET
                             .withNamespace(StandardNamespace.PROPERTY)
                             .named(getNameSegment(tokens, name, 2));
+                case "SETELEMENT":
+                    // Set an object property as if by "[]", with a property on the stack
+                    return RhinoOperation.SETELEMENT.withNamespace(StandardNamespace.PROPERTY);
+                case "SETINDEX":
+                    // Same but the property name is definitely a number
+                    return RhinoOperation.SETINDEX.withNamespace(StandardNamespace.PROPERTY);
             }
         } else if ("NAME".equals(namespaceName)) {
             switch (opName) {
                 case "BIND":
+                    // Bind a new variable to the context with a constant name
                     return RhinoOperation.BIND
                             .withNamespace(RhinoNamespace.NAME)
                             .named(getNameSegment(tokens, name, 2));
                 case "GET":
+                    // Get a variable from the context with a constant name
                     return StandardOperation.GET
                             .withNamespace(RhinoNamespace.NAME)
                             .named(getNameSegment(tokens, name, 2));
                 case "GETWITHTHIS":
+                    // Same but also return "this" so that it is found by "lastStoredScriptable"
                     return RhinoOperation.GETWITHTHIS
+                            .withNamespace(RhinoNamespace.NAME)
+                            .named(getNameSegment(tokens, name, 2));
+                case "SET":
+                    // Set an object in the context with a constant name
+                    return StandardOperation.SET
+                            .withNamespace(RhinoNamespace.NAME)
+                            .named(getNameSegment(tokens, name, 2));
+                case "SETSTRICT":
+                    // Same but implement strict mode checks
+                    return RhinoOperation.SETSTRICT
+                            .withNamespace(RhinoNamespace.NAME)
+                            .named(getNameSegment(tokens, name, 2));
+                case "SETCONST":
+                    // Same but try to set a constant
+                    return RhinoOperation.SETCONST
                             .withNamespace(RhinoNamespace.NAME)
                             .named(getNameSegment(tokens, name, 2));
             }
@@ -101,10 +136,9 @@ public class Bootstrapper {
 
     // Given a list of name segments and a position, return the interned name at the
     // specified position.
-    private static String getNameSegment(String[] segments, String name, int pos)
-            throws NoSuchMethodException {
+    private static String getNameSegment(String[] segments, String name, int pos) {
         if (pos >= segments.length) {
-            throw new NoSuchMethodException(name);
+            return "";
         }
         // Because segments of operation names, especially property names, are essentially
         // wired in to the bootstrapping result, interning works and has a big impact on

--- a/rhino/src/main/java/org/mozilla/javascript/optimizer/Bootstrapper.java
+++ b/rhino/src/main/java/org/mozilla/javascript/optimizer/Bootstrapper.java
@@ -1,0 +1,114 @@
+package org.mozilla.javascript.optimizer;
+
+import java.lang.invoke.CallSite;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodType;
+import java.util.regex.Pattern;
+import jdk.dynalink.CallSiteDescriptor;
+import jdk.dynalink.DynamicLinker;
+import jdk.dynalink.DynamicLinkerFactory;
+import jdk.dynalink.Operation;
+import jdk.dynalink.StandardNamespace;
+import jdk.dynalink.StandardOperation;
+import jdk.dynalink.support.SimpleRelinkableCallSite;
+import org.mozilla.classfile.ByteCode;
+import org.mozilla.classfile.ClassFileWriter;
+
+/**
+ * The Bootstrapper contains the method that is called by invokedynamic instructions in the bytecode
+ * to map a call site to a method.
+ */
+public class Bootstrapper {
+    private static final Pattern SEPARATOR = Pattern.compile(":");
+
+    public static final ClassFileWriter.MHandle BOOTSTRAP_HANDLE =
+            new ClassFileWriter.MHandle(
+                    ByteCode.MH_INVOKESTATIC,
+                    "org.mozilla.javascript.optimizer.Bootstrapper",
+                    "bootstrap",
+                    "(Ljava/lang/invoke/MethodHandles$Lookup;"
+                            + "Ljava/lang/String;Ljava/lang/invoke/MethodType;)Ljava/lang/invoke/CallSite;");
+
+    private static final DynamicLinker linker;
+
+    static {
+        // Set up the linkers that will be invoked whenever a call site needs to be resolved.
+        DynamicLinkerFactory factory = new DynamicLinkerFactory();
+        factory.setPrioritizedLinkers(new DefaultLinker());
+        linker = factory.createLinker();
+    }
+
+    /** This is the method called by every call site in the bytecode to map it to a function. */
+    @SuppressWarnings("unused")
+    public static CallSite bootstrap(MethodHandles.Lookup lookup, String name, MethodType mType)
+            throws NoSuchMethodException, IllegalAccessException {
+        Operation op = parseOperation(name);
+        // For now, use a very simple call site.
+        // When we change to add more linkers, we will likely switch to ChainedCallSite.
+        return linker.link(new SimpleRelinkableCallSite(new CallSiteDescriptor(lookup, op, mType)));
+    }
+
+    /**
+     * Operation names in the bytecode are names like "PROP:GET:<NAME> and "NAME:BIND:<NAME>". This
+     * translates them the first time a call site is seen to an object that can be easily consumed
+     * by the various types of linkers.
+     */
+    private static Operation parseOperation(String name) throws NoSuchMethodException {
+        String[] tokens = SEPARATOR.split(name, -1);
+        String namespaceName = getNameSegment(tokens, name, 0);
+        String opName = getNameSegment(tokens, name, 1);
+
+        if ("PROP".equals(namespaceName)) {
+            switch (opName) {
+                case "GET":
+                    return StandardOperation.GET
+                            .withNamespace(StandardNamespace.PROPERTY)
+                            .named(getNameSegment(tokens, name, 2));
+                case "GETNOWARN":
+                    return RhinoOperation.GETNOWARN
+                            .withNamespace(StandardNamespace.PROPERTY)
+                            .named(getNameSegment(tokens, name, 2));
+                case "GETWITHTHIS":
+                    return RhinoOperation.GETWITHTHIS
+                            .withNamespace(StandardNamespace.PROPERTY)
+                            .named(getNameSegment(tokens, name, 2));
+                case "SET":
+                    return StandardOperation.SET
+                            .withNamespace(StandardNamespace.PROPERTY)
+                            .named(getNameSegment(tokens, name, 2));
+            }
+        } else if ("NAME".equals(namespaceName)) {
+            switch (opName) {
+                case "BIND":
+                    return RhinoOperation.BIND
+                            .withNamespace(RhinoNamespace.NAME)
+                            .named(getNameSegment(tokens, name, 2));
+                case "GET":
+                    return StandardOperation.GET
+                            .withNamespace(RhinoNamespace.NAME)
+                            .named(getNameSegment(tokens, name, 2));
+                case "GETWITHTHIS":
+                    return RhinoOperation.GETWITHTHIS
+                            .withNamespace(RhinoNamespace.NAME)
+                            .named(getNameSegment(tokens, name, 2));
+            }
+        }
+
+        // Fall through to no match. This should only happen if the name in the bytecode
+        // does not match the pattern that this method understands.
+        throw new NoSuchMethodException(name);
+    }
+
+    // Given a list of name segments and a position, return the interned name at the
+    // specified position.
+    private static String getNameSegment(String[] segments, String name, int pos)
+            throws NoSuchMethodException {
+        if (pos >= segments.length) {
+            throw new NoSuchMethodException(name);
+        }
+        // Because segments of operation names, especially property names, are essentially
+        // wired in to the bootstrapping result, interning works and has a big impact on
+        // performance.
+        return segments[pos].intern();
+    }
+}

--- a/rhino/src/main/java/org/mozilla/javascript/optimizer/DefaultLinker.java
+++ b/rhino/src/main/java/org/mozilla/javascript/optimizer/DefaultLinker.java
@@ -1,0 +1,160 @@
+package org.mozilla.javascript.optimizer;
+
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodType;
+import jdk.dynalink.NamedOperation;
+import jdk.dynalink.NamespaceOperation;
+import jdk.dynalink.Operation;
+import jdk.dynalink.StandardNamespace;
+import jdk.dynalink.StandardOperation;
+import jdk.dynalink.linker.GuardedInvocation;
+import jdk.dynalink.linker.GuardingDynamicLinker;
+import jdk.dynalink.linker.LinkRequest;
+import jdk.dynalink.linker.LinkerServices;
+import org.mozilla.javascript.ScriptRuntime;
+
+/**
+ * This linker is the last one in the chain, and as such it must be able to link every type of
+ * operation that we support. It links every operation to the corresponding ScriptRuntime or
+ * OptRuntime operation that was used in the bytecode before we introduced dynamic linking.
+ */
+class DefaultLinker implements GuardingDynamicLinker {
+    static final boolean DEBUG;
+
+    static {
+        String debugVal = System.getProperty("RHINO_DEBUG_LINKER");
+        if (debugVal == null) {
+            debugVal = System.getenv("RHINO_DEBUG_LINKER");
+        }
+        DEBUG = Boolean.parseBoolean(debugVal);
+    }
+
+    @Override
+    public GuardedInvocation getGuardedInvocation(LinkRequest req, LinkerServices svc)
+            throws NoSuchMethodException, IllegalAccessException {
+        MethodHandles.Lookup lookup = MethodHandles.lookup();
+        Operation rootOp = req.getCallSiteDescriptor().getOperation();
+        MethodType mType = req.getCallSiteDescriptor().getMethodType();
+
+        // So far, every operation in our application is a NamedOperation, but if
+        // we add non-named operations in the future, this will still work because
+        // "getName" will return an empty string and "Op" will return "rootOp".
+        String name = getName(rootOp);
+        Operation op = NamedOperation.getBaseOperation(rootOp);
+
+        // In our application, every operation has a namespace.
+        if (!(op instanceof NamespaceOperation)) {
+            throw new UnsupportedOperationException(op.toString());
+        }
+        NamespaceOperation nsOp = (NamespaceOperation) op;
+        op = NamespaceOperation.getBaseOperation(op);
+
+        GuardedInvocation invocation = getInvocation(lookup, mType, rootOp, nsOp, op, name);
+        if (DEBUG) {
+            System.out.println(rootOp + ": default link");
+        }
+        return invocation;
+    }
+
+    private GuardedInvocation getInvocation(
+            MethodHandles.Lookup lookup,
+            MethodType mType,
+            Operation rootOp,
+            NamespaceOperation nsOp,
+            Operation op,
+            String name)
+            throws NoSuchMethodException, IllegalAccessException {
+        if (nsOp.contains(StandardNamespace.PROPERTY)) {
+            return getPropertyInvocation(lookup, mType, rootOp, op, name);
+        } else if (nsOp.contains(RhinoNamespace.NAME)) {
+            return getNameInvocation(lookup, mType, rootOp, op, name);
+        }
+        throw new UnsupportedOperationException(rootOp.toString());
+    }
+
+    private GuardedInvocation getPropertyInvocation(
+            MethodHandles.Lookup lookup,
+            MethodType mType,
+            Operation rootOp,
+            Operation op,
+            String name)
+            throws NoSuchMethodException, IllegalAccessException {
+        MethodType tt;
+        MethodHandle mh = null;
+
+        // The name of the property to look up is now not on the Java stack,
+        // but was passed as part of the operation name in the bytecode.
+        // Put the property name back in the right place in the parameter list
+        // so that we can invoke the operation normally.
+        if (StandardOperation.GET.equals(op)) {
+            tt = mType.insertParameterTypes(1, String.class);
+            mh = lookup.findStatic(ScriptRuntime.class, "getObjectProp", tt);
+            mh = MethodHandles.insertArguments(mh, 1, name);
+        } else if (RhinoOperation.GETNOWARN.equals(op)) {
+            tt = mType.insertParameterTypes(1, String.class);
+            mh = lookup.findStatic(ScriptRuntime.class, "getObjectPropNoWarn", tt);
+            mh = MethodHandles.insertArguments(mh, 1, name);
+        } else if (RhinoOperation.GETWITHTHIS.equals(op)) {
+            tt = mType.insertParameterTypes(1, String.class);
+            mh = lookup.findStatic(ScriptRuntime.class, "getPropFunctionAndThis", tt);
+            mh = MethodHandles.insertArguments(mh, 1, name);
+        } else if (StandardOperation.SET.equals(op)) {
+            tt = mType.insertParameterTypes(1, String.class);
+            mh = lookup.findStatic(ScriptRuntime.class, "setObjectProp", tt);
+            mh = MethodHandles.insertArguments(mh, 1, name);
+        }
+
+        if (mh != null) {
+            return new GuardedInvocation(mh);
+        }
+        // We will only get here if a new operation was introduced
+        // without appropriate changes. This particular linker must never return null.
+        throw new UnsupportedOperationException(rootOp.toString());
+    }
+
+    private GuardedInvocation getNameInvocation(
+            MethodHandles.Lookup lookup,
+            MethodType mType,
+            Operation rootOp,
+            Operation op,
+            String name)
+            throws NoSuchMethodException, IllegalAccessException {
+        MethodType tt;
+        MethodHandle mh = null;
+
+        // Like above for properties, the name to handle is not on the Java stack,
+        // but is something that we parsed from the name of the invokedynamic operation.
+        if (RhinoOperation.BIND.equals(op)) {
+            tt = mType.insertParameterTypes(2, String.class);
+            mh = lookup.findStatic(ScriptRuntime.class, "bind", tt);
+            mh = MethodHandles.insertArguments(mh, 2, name);
+        } else if (StandardOperation.GET.equals(op)) {
+            tt = mType.insertParameterTypes(2, String.class);
+            mh = lookup.findStatic(ScriptRuntime.class, "name", tt);
+            mh = MethodHandles.insertArguments(mh, 2, name);
+        } else if (RhinoOperation.GETWITHTHIS.equals(op)) {
+            tt = mType.insertParameterTypes(0, String.class);
+            mh = lookup.findStatic(ScriptRuntime.class, "getNameFunctionAndThis", tt);
+            mh = MethodHandles.insertArguments(mh, 0, name);
+        }
+
+        if (mh != null) {
+            return new GuardedInvocation(mh);
+        }
+        throw new UnsupportedOperationException(rootOp.toString());
+    }
+
+    // If the operation is a named operation, then return the name,
+    // or the empty string if it's not.
+    static String getName(Operation op) {
+        Object nameObj = NamedOperation.getName(op);
+        if (nameObj instanceof String) {
+            return (String) nameObj;
+        } else if (nameObj != null) {
+            throw new UnsupportedOperationException(op.toString());
+        } else {
+            return "";
+        }
+    }
+}

--- a/rhino/src/main/java/org/mozilla/javascript/optimizer/RhinoNamespace.java
+++ b/rhino/src/main/java/org/mozilla/javascript/optimizer/RhinoNamespace.java
@@ -1,0 +1,11 @@
+package org.mozilla.javascript.optimizer;
+
+import jdk.dynalink.Namespace;
+
+/**
+ * A list of namespaces for operations that are specific to Rhino, on top of standard namespaces
+ * like "Property".
+ */
+public enum RhinoNamespace implements Namespace {
+    NAME,
+}

--- a/rhino/src/main/java/org/mozilla/javascript/optimizer/RhinoOperation.java
+++ b/rhino/src/main/java/org/mozilla/javascript/optimizer/RhinoOperation.java
@@ -1,0 +1,14 @@
+package org.mozilla.javascript.optimizer;
+
+import jdk.dynalink.Operation;
+
+/**
+ * A list of operation types used that are specific to Rhino, in addition to standard operations
+ * like GET and SET...
+ */
+public enum RhinoOperation implements Operation {
+    BIND,
+    GETNOWARN,
+    GETWITHTHIS,
+    SETSTRICT,
+}

--- a/rhino/src/main/java/org/mozilla/javascript/optimizer/RhinoOperation.java
+++ b/rhino/src/main/java/org/mozilla/javascript/optimizer/RhinoOperation.java
@@ -10,5 +10,10 @@ public enum RhinoOperation implements Operation {
     BIND,
     GETNOWARN,
     GETWITHTHIS,
+    GETELEMENT,
+    GETINDEX,
     SETSTRICT,
+    SETCONST,
+    SETELEMENT,
+    SETINDEX,
 }

--- a/tests/src/test/java/org/mozilla/javascript/tests/DefaultParametersTest.java
+++ b/tests/src/test/java/org/mozilla/javascript/tests/DefaultParametersTest.java
@@ -313,7 +313,6 @@ public class DefaultParametersTest {
     }
 
     @Test
-    @Ignore("deeply-nested-literal-not-supported")
     public void deeplyNestedObjectLiteral() throws Exception {
         final String script =
                 "let { d: { b }, d, a} = { \n"
@@ -325,7 +324,7 @@ public class DefaultParametersTest {
                         + "                        \n";
         assertEvaluates("hello", script + "b");
         assertEvaluates("world", script + "a");
-        assertEvaluates("hello", script + "d[b]");
+        assertEvaluates("hello", script + "d.b");
     }
 
     @Test


### PR DESCRIPTION
This begins to use invokedynamic instructions in Rhino's bytecode.

It replaces the operations that call the ScriptRuntime operations for
common property operations like setting and getting properties and 
elements, and common context operations like setting and getting variables,
with invokedynamic instructions.

It also adds components that will wire up those invokedynamic instructions
to the appropriate ScriptRuntime operations using the Dynalink package.

The result should be that Rhino behaves exactly the same and performs the same
as well. 

However, once this is implemented we can begin to create additional dynalink
"linkers" that do specific things to optimize performance based on what is 
happening at runtime.
